### PR TITLE
chore: 리뷰어 자동 지정 액션

### DIFF
--- a/.github/add-reviewers-config.yml
+++ b/.github/add-reviewers-config.yml
@@ -1,0 +1,7 @@
+addReviewers: true
+addAssignees: author
+reviewers:
+  - Choiyu330
+  - kimmj13
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0

--- a/.github/workflows/add-reviewers.yml
+++ b/.github/workflows/add-reviewers.yml
@@ -1,0 +1,13 @@
+name: Add Reviewers
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.1
+        with:
+          configuration-path: '.github/add-reviewers-config.yml'


### PR DESCRIPTION
리뷰어 자동 지정 깃헙 액션을 설정하는 PR 입니다.

PR 생성 또는 draft -> open 상태가 되었을 때 Assignees와 Reviewers를 자동으로 지정해줍니다!

슬랙과 깃헙 계정을 연동해두셨으면 슬랙 노티피케이션에 멘션이 달릴거에요!